### PR TITLE
Add a default parameter to `configmanager.get_prop` 

### DIFF
--- a/source/dapsenv/argparser.py
+++ b/source/dapsenv/argparser.py
@@ -111,10 +111,7 @@ class ArgParser:
         logmanager_ip = configmanager.get_prop("logmanager_ip", default='127.0.0.1')
 
         logserver_port = 5556
-        try:
-            logserver_port = int(configmanager.get_prop("logserver_port"))
-        except ValueError:
-            pass
+        logserver_port = int(configmanager.get_prop("logserver_port", default=logserver_port))
 
         cmd = self.cmdSubParser.add_parser(
             "daemon", aliases=["d"], help="This command starts a daemon which takes care of "
@@ -165,10 +162,7 @@ class ArgParser:
         default_ip = configmanager.get_prop("api_client_default_ip", default='127.0.0.1')
 
         default_port = 5555
-        try:
-            default_port = int(configmanager.get_prop("api_client_default_port"))
-        except ValueError:
-            pass
+        default_port = int(configmanager.get_prop("api_client_default_port", default=default_port))
 
         cmd = self.cmdSubParser.add_parser(
             "status", aliases=["s"], help="Queries a DapsEnv API server."
@@ -188,10 +182,7 @@ class ArgParser:
         default_ip = configmanager.get_prop("api_client_default_ip", default='127.0.0.1')
 
         default_port = 5555
-        try:
-            default_port = int(configmanager.get_prop("api_client_default_port"))
-        except ValueError:
-            pass
+        default_port = int(configmanager.get_prop("api_client_default_port", default=default_port))
 
         cmd = self.cmdSubParser.add_parser(
             "trigger-build", aliases=["tb"], help="Triggers a build on a DapsEnv instance."
@@ -221,10 +212,7 @@ class ArgParser:
         default_ip = configmanager.get_prop("api_client_default_ip", default='127.0.0.1')
 
         default_port = 5555
-        try:
-            default_port = int(configmanager.get_prop("api_client_default_port"))
-        except ValueError:
-            pass
+        default_port = int(configmanager.get_prop("api_client_default_port", default=default_port))
 
         cmd = self.cmdSubParser.add_parser(
             "project-list", aliases=["pl"], help="Retrieves a list of all projects on a "
@@ -277,10 +265,7 @@ class ArgParser:
         default_ip = configmanager.get_prop("api_client_default_ip", default='127.0.0.1')
 
         default_port = 5555
-        try:
-            default_port = int(configmanager.get_prop("api_client_default_port"))
-        except ValueError:
-            pass
+        default_port = int(configmanager.get_prop("api_client_default_port", default=default_port))
 
         cmd = self.cmdSubParser.add_parser(
             "view-log", aliases=["vl"], help="Shows the log result of a failed build."

--- a/source/dapsenv/argparser.py
+++ b/source/dapsenv/argparser.py
@@ -108,10 +108,7 @@ class ArgParser:
         )
 
     def addDaemonCommand(self):
-        logmanager_ip = configmanager.get_prop("logmanager_ip")
-        if not logmanager_ip:
-            default_ip = "127.0.0.1"
-            log.debug("Set logmanager_ip to %r", default_ip)
+        logmanager_ip = configmanager.get_prop("logmanager_ip", default='127.0.0.1')
 
         logserver_port = 5556
         try:
@@ -165,9 +162,7 @@ class ArgParser:
         )
 
     def addStatusCommand(self):
-        default_ip = configmanager.get_prop("api_client_default_ip")
-        if not default_ip:
-            default_ip = "127.0.0.1"
+        default_ip = configmanager.get_prop("api_client_default_ip", default='127.0.0.1')
 
         default_port = 5555
         try:
@@ -190,9 +185,7 @@ class ArgParser:
         )
 
     def addTriggerBuildCommand(self):
-        default_ip = configmanager.get_prop("api_client_default_ip")
-        if not default_ip:
-            default_ip = "127.0.0.1"
+        default_ip = configmanager.get_prop("api_client_default_ip", default='127.0.0.1')
 
         default_port = 5555
         try:
@@ -225,9 +218,7 @@ class ArgParser:
         )
 
     def addProjectListCommand(self):
-        default_ip = configmanager.get_prop("api_client_default_ip")
-        if not default_ip:
-            default_ip = "127.0.0.1"
+        default_ip = configmanager.get_prop("api_client_default_ip", default='127.0.0.1')
 
         default_port = 5555
         try:
@@ -283,9 +274,7 @@ class ArgParser:
         )
 
     def addViewLogCommand(self):
-        default_ip = configmanager.get_prop("api_client_default_ip")
-        if not default_ip:
-            default_ip = "127.0.0.1"
+        default_ip = configmanager.get_prop("api_client_default_ip", default='127.0.0.1')
 
         default_port = 5555
         try:

--- a/source/dapsenv/configmanager.py
+++ b/source/dapsenv/configmanager.py
@@ -31,14 +31,14 @@ log = logging.getLogger(__name__)
 _search_pattern = re.compile("(?!#)(?P<key>[\w\d]+)\s*=\s*(?P<value>.*)")
 
 
-def get_prop(prop, config_type="", config_path=""):
+def get_prop(prop, config_type="", config_path="", default=None):
     """Returns the value of a property - should be used from other modules only!
 
     :param string prop: The requested property
     :param string config_type: The type of the config (global, user, own)
     :param string config_path: Sets the path for a configuration file (only required if "own"
                                is set in config_type)
-    :return string: The value of the property or None
+    :return string: The value of the property or default (if no config file are found).
     """
     paths = []
 
@@ -51,7 +51,12 @@ def get_prop(prop, config_type="", config_path=""):
         if os.path.exists(user_path):
             paths.append(user_path)
 
-    return get_property_value(prop, paths)
+    for path in paths:
+        if not isfile(path):
+            log.warning("No config file found. Return default '%s' for '%s'", default, prop)
+            return default
+        else:
+            return get_property_value(prop, paths)
 
 
 def set_prop(prop, value, config_type="", config_path=""):


### PR DESCRIPTION
Fixes #16 
`get_prop` returns the given default value if no config file is found.
Furthermore it provides cleaner code.